### PR TITLE
feat: add awards banner structured data

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,6 +171,30 @@
 
   <main id="main">
 
+    <section id="awards" class="fade-up">
+      <div class="container">
+        <h2>2024 Awards</h2>
+        <p>Recognized as the Top Agent across Commercial, Industrial, and Residential categories by Royal LePage Global Force Realty.</p>
+        <script type="application/ld+json">
+        {
+          "@context": "https://schema.org",
+          "@type": "Award",
+          "name": "Top Agent",
+          "description": "Commercial, Industrial, and Residential Top Agent.",
+          "awardYear": "2024",
+          "sponsor": {
+            "@type": "Organization",
+            "name": "Royal LePage Global Force Realty"
+          },
+          "recipient": {
+            "@type": "Person",
+            "name": "Ishwinder Ghag"
+          }
+        }
+        </script>
+      </div>
+    </section>
+
     <!-- Auto‑qualify: tiny quiz that branches to CTAs and stores intent -->
     <section id="quiz">
       <div class="container">


### PR DESCRIPTION
## Summary
- add awards section with heading and description for search indexing
- embed JSON-LD describing Top Agent 2024 award and recipient

## Testing
- `npm test` *(fails: Could not read package.json)*
- `curl -X POST ...internalapi/validate` *(404: The requested URL was not found on this server)*

------
https://chatgpt.com/codex/tasks/task_e_68ab55c8f1ec83278438599994daff15