### PR TITLE
embed awards banner via data uri

### DIFF
--- a/index.html
+++ b/index.html
@@ -175,6 +175,9 @@
     <section id="awards" class="fade-up">
       <div class="container">
         <h2>2024 Awards</h2>
+        <picture>
+          <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSI2MDAiIGhlaWdodD0iMjAwIj48cmVjdCB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiBmaWxsPSIjZjhmOWZhIi8+PHRleHQgeD0iNTAlIiB5PSI1MCUiIGRvbWluYW50LWJhc2VsaW5lPSJtaWRkbGUiIHRleHQtYW5jaG9yPSJtaWRkbGUiIGZvbnQtc2l6ZT0iNDgiIGZpbGw9IiMzMzMiPlRvcCBBZ2VudDwvdGV4dD48L3N2Zz4=" alt="Top Agent award banner" width="600" height="200" loading="lazy" style="width:100%;height:auto">
+        </picture>
         <p>Recognized as the Top Agent across Commercial, Industrial, and Residential categories by Royal LePage Global Force Realty.</p>
         <script type="application/ld+json">
         {


### PR DESCRIPTION
## Summary
- inline the Awards section banner image using a base64-encoded SVG

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `head -n 5 /tmp/banner.svg`


------
https://chatgpt.com/codex/tasks/task_e_68ab57d737a08327a2fbb73e8d4dcdec