### PR TITLE
Refine numeric sanitization and handling

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -161,10 +161,12 @@
         return div.textContent;
       }
       function sanitizeNumberString(str){
-        return (str||'').replace(/[^\d.-]/g,'');
+        return (str||'').match(/^(-?\d*(?:\.\d*)?)$/)?.[1] ?? '';
       }
       function parseNum(val){
-        return parseFloat(sanitizeNumberString(val))||0;
+        const clean = sanitizeNumberString(val);
+        if(clean==='') return 0;
+        return parseFloat(clean) || 0;
       }
       function attachNumericSanitizer(el){
         if(!el) return;


### PR DESCRIPTION
## Summary
- Restrict numeric input sanitizer to an optional leading minus and single decimal.
- Ensure `parseNum` returns 0 when sanitization yields an empty string.

## Testing
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68ab5c0cb48483279d8d9b9260df4298