### PR TITLE
Add CORS headers and OPTIONS handling to contact API

### DIFF
--- a/api/contact.js
+++ b/api/contact.js
@@ -5,7 +5,15 @@ function sanitize(str){
 }
 
 exports.handler = async (event) => {
-  const headers = { 'Content-Type': 'application/json' };
+  const headers = {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Methods': 'POST,OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type'
+  };
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 200, headers };
+  }
   if (event.httpMethod !== 'POST') {
     return { statusCode: 405, headers, body: JSON.stringify({ success: false, error: 'Method Not Allowed' }) };
   }


### PR DESCRIPTION
## Summary
- allow cross-origin requests in contact API by adding appropriate headers
- respond to OPTIONS preflight requests

## Testing
- `node -e "require('./api/contact.js')"`


------
https://chatgpt.com/codex/tasks/task_e_68ab5c1102348327b3342014fb59cd79