### PR TITLE
fix: skip carousel init when root missing

### DIFF
--- a/scripts/main.js
+++ b/scripts/main.js
@@ -58,6 +58,7 @@
     // Simple carousel with controls + keyboard + pause + a11y states
     (function(){
       const root = document.getElementById('carousel');
+      if(!root) return;
       const slides = root.querySelector('.slides');
       const frames = Array.from(slides.children);
       const total = frames.length;


### PR DESCRIPTION
## Summary
- prevent JS errors on pages without carousel element by returning early when `#carousel` is missing

## Testing
- `node - <<'NODE'
(function(){
  const root = null;
  if(!root) return;
  root.querySelector('.slides');
})();
console.log('executed without error');
NODE`
- `npm test` *(fails: ENOENT Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5c0f5cc88327829ab7d275567481