### PR TITLE
Enforce message field input in contact form

### DIFF
--- a/index.html
+++ b/index.html
@@ -286,7 +286,7 @@
                 </p>
                 <p>
                   <label class="visually-hidden" for="message">Message</label>
-                  <textarea id="message" name="message" rows="5" placeholder="Tell me about your requirement" class="w-full p-3.5 rounded-xl border border-[var(--line)]"></textarea>
+                  <textarea id="message" name="message" rows="5" required placeholder="Tell me about your requirement" class="w-full p-3.5 rounded-xl border border-[var(--line)]"></textarea>
                 </p>
               <button class="btn" type="submit">Send</button>
               <p id="contactResult" class="small" role="status" aria-live="polite"></p>


### PR DESCRIPTION
## Summary
- require message text in the contact form

## Testing
- `node -e "const puppeteer=require('puppeteer');(async()=>{const browser=await puppeteer.launch({args:['--no-sandbox']});const page=await browser.newPage();await page.goto('file://'+process.cwd()+'/index.html');await page.type('#name','John');await page.type('#email','john@example.com');const validBefore=await page.$eval('#contactForm',f=>f.checkValidity());console.log('validBeforeMessageFilled=',validBefore);await page.type('#message','Hello');const validAfter=await page.$eval('#contactForm',f=>f.checkValidity());console.log('validAfterMessageFilled=',validAfter);await browser.close();})()"`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ab5daae7f08327b69fe641b07f0c5e