### PR TITLE
Handle base64 encoded request body

### DIFF
--- a/api/contact.js
+++ b/api/contact.js
@@ -19,10 +19,14 @@ exports.handler = async (event) => {
   try {
     let data;
     const contentType = event.headers['content-type'] || '';
+    const rawBody = event.body || '';
+    const body = event.isBase64Encoded
+      ? Buffer.from(rawBody, 'base64').toString('utf8')
+      : rawBody;
     if (contentType.includes('application/json')) {
-      data = JSON.parse(event.body || '{}');
+      data = JSON.parse(body || '{}');
     } else {
-      data = qs.parse(event.body || '');
+      data = qs.parse(body || '');
     }
     const name = sanitize(data.name);
     const email = sanitize(data.email);


### PR DESCRIPTION
## Summary
- decode base64-encoded request bodies when `event.isBase64Encoded` is true before parsing

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node api/contact.js` with base64 encoded event
- `node api/contact.js` with plain JSON body

------
https://chatgpt.com/codex/tasks/task_e_68ab5dac6a3483278b9c3685dd7e1ace