### PR TITLE
Initialize widgets on DOMContentLoaded

### DIFF
--- a/index.html
+++ b/index.html
@@ -571,5 +571,13 @@
     <script defer src="/js/onepager.js"></script>
     <script defer src="/js/forms.js"></script>
     <script defer src="scripts/main.js"></script>
+    <script>
+      document.addEventListener('DOMContentLoaded', () => {
+        window.initLightbox?.();
+        window.initShortlist?.();
+        window.initOnePager?.();
+        window.initForms?.();
+      });
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add an inline DOMContentLoaded listener in `index.html` to trigger lightbox, shortlist, one-pager, and form initializers after the deferred scripts load

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd6f9ef9b08327a3c0f750af5119b3