### PR TITLE
Add saved listings section to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,6 +212,17 @@
       </div>
     </section>
 
+    <section id="saved-listings" class="fade-up">
+      <div class="container">
+        <div class="section-title">
+          <h2>Saved Listings</h2>
+        </div>
+        <div id="shortlist-cards" class="grid" aria-live="polite">
+          <p class="small">Tap the ⭐ on any listing to save it here.</p>
+        </div>
+      </div>
+    </section>
+
     <section id="services">
       <div class="container">
         <div class="section-title"><h2>Advisory & Brokerage Services</h2></div>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -460,3 +460,5 @@ I am an ' + v + ' interested in touring...'); }
         }
       });
     })();
+
+    window.initShortlist?.();


### PR DESCRIPTION
## Summary
- add a Saved Listings section to the homepage so shortlist cards have a visible home
- auto-run the shortlist initializer during main script boot so the saved listings render into the new section

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dd6fa496908327a43820e155abdf52