### PR TITLE
Hydrate listings UI with dynamic renderer

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,7 @@
   <link rel="preload" as="image" href="/assets/ishwinder/hero-1280.jpg" imagesrcset="/assets/ishwinder/hero-1920.jpg 1920w, /assets/ishwinder/hero-1280.jpg 1280w, /assets/ishwinder/hero-960.jpg 960w" imagesizes="100vw">
 
   <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin="" />
   <link rel="stylesheet" href="styles/main.css">
 </head>
 <body>
@@ -148,67 +149,7 @@
           <h2>Featured Listings</h2>
           <div><span class="pill">Land</span><span class="pill">Industrial</span><span class="pill">Investment</span></div>
         </div>
-        <div class="grid">
-
-          <!-- Listing 1: 17895 96 Ave, Surrey (Port Kells) -->
-          <article class="card col-6 fade-up" itemscope itemtype="https://schema.org/RealEstateListing">
-            <picture itemprop="image">
-              <source type="image/avif" srcset="https://picsum.photos/id/1062/640/360.avif 640w, https://picsum.photos/id/1062/960/540.avif 960w, https://picsum.photos/id/1062/1280/720.avif 1280w" sizes="(min-width:900px) 50vw, 100vw">
-              <source type="image/jpeg" srcset="https://picsum.photos/id/1062/640/360 640w, https://picsum.photos/id/1062/960/540 960w, https://picsum.photos/id/1062/1280/720 1280w" sizes="(min-width:900px) 50vw, 100vw">
-                <img class="listing-photo w-full h-auto block" src="https://picsum.photos/id/1062/1280/720" alt="Port Kells light industrial lot" width="1280" height="720" loading="lazy">
-            </picture>
-            <div class="card-body">
-                <h3 class="m-0" itemprop="name">Surrey | 17895 96 Avenue (Port Kells)</h3>
-              <div class="meta" itemprop="description">1.544 acres • Corner lot • Designated IL (Light Industrial)</div>
-                <div class="price font-extrabold" itemprop="offers" itemscope itemtype="https://schema.org/Offer">
-                <span itemprop="priceCurrency" content="CAD">$</span><span itemprop="price" content="6650000">6,650,000</span>
-              </div>
-                <details class="mt-2">
-                  <summary class="small cursor-pointer">Highlights</summary>
-                <ul>
-                  <li>2,454 sf 2‑storey home (4 bed / 3 bath) + ~1,100 sf shop (12' ceiling)</li>
-                  <li>Dual frontages: 96 Ave & 179 St • Easy access to Hwy‑1, 17, 15, Golden Ears</li>
-                  <li>Potential TUP corridor uses (storage & truck parking)</li>
-                  <li>Freehold • Built 1981 • 2024 taxes: $6,299</li>
-                </ul>
-                <p class="small">Lot: 198' x 339' (1.54 ac) • Community: Port Kells • MLS®: R3015679 • Days on market: 55</p>
-              </details>
-                <div class="mt-3">
-                  <iframe title="Map - 17895 96 Avenue, Surrey, BC V4N 4A9" loading="lazy" class="border-0 w-full h-[260px] rounded-xl" src="https://www.google.com/maps?q=17895%2096%20Avenue%2C%20Surrey%2C%20BC%20V4N%204A9&output=embed" referrerpolicy="no-referrer-when-downgrade"></iframe>
-                </div>
-            </div>
-          </article>
-
-          <!-- Listing 2: 3271 196 St, Surrey (Campbell Heights) -->
-          <article class="card col-6 fade-up" itemscope itemtype="https://schema.org/RealEstateListing">
-            <picture itemprop="image">
-              <source type="image/avif" srcset="https://picsum.photos/id/1084/640/360.avif 640w, https://picsum.photos/id/1084/960/540.avif 960w, https://picsum.photos/id/1084/1280/720.avif 1280w" sizes="(min-width:900px) 50vw, 100vw">
-              <source type="image/jpeg" srcset="https://picsum.photos/id/1084/640/360 640w, https://picsum.photos/id/1084/960/540 960w, https://picsum.photos/id/1084/1280/720 1280w" sizes="(min-width:900px) 50vw, 100vw">
-                <img class="listing-photo w-full h-auto block" src="https://picsum.photos/id/1084/1280/720" alt="Campbell Heights business park parcel" width="1280" height="720" loading="lazy">
-            </picture>
-            <div class="card-body">
-                <h3 class="m-0" itemprop="name">Surrey | 3271 196 Street (Campbell Heights)</h3>
-              <div class="meta" itemprop="description">43,553 sf (0.999 acre) • Campbell Heights Business Park • Light Industrial (IL)</div>
-                <div class="price font-extrabold" itemprop="offers" itemscope itemtype="https://schema.org/Offer">
-                <span itemprop="priceCurrency" content="CAD">$</span><span itemprop="price" content="3750000">3,750,000</span>
-              </div>
-                <details class="mt-2">
-                  <summary class="small cursor-pointer">Highlights</summary>
-                <ul>
-                  <li>Adjacent parcels received 3rd reading for rezoning</li>
-                  <li>Services to lot line with adjacent development</li>
-                  <li>Positioned to participate in Campbell Heights growth</li>
-                  <li>Built 1954 • 2024 taxes: $19,273</li>
-                </ul>
-                <p class="small">Lot: 94' x 461' (43,553 sf) • Community: Serpentine • MLS®: R3029310 • Days on market: 22</p>
-              </details>
-                <div class="mt-3">
-                  <iframe title="Map - 3271 196 Street, Surrey, BC V3S 0L5" loading="lazy" class="border-0 w-full h-[260px] rounded-xl" src="https://www.google.com/maps?q=3271%20196%20Street%2C%20Surrey%2C%20BC%20V3S%200L5&output=embed" referrerpolicy="no-referrer-when-downgrade"></iframe>
-                </div>
-            </div>
-          </article>
-
-        </div>
+        <div id="listing-app"></div>
       </div>
     </section>
 
@@ -566,10 +507,18 @@
     ]
   }
   </script>
-    <script defer src="/js/lightbox.js"></script>
-    <script defer src="/js/shortlist.js"></script>
-    <script defer src="/js/onepager.js"></script>
-    <script defer src="/js/forms.js"></script>
-    <script defer src="scripts/main.js"></script>
+  <script defer src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCch5H+3SVu2V0Sss6X0rYJOGX4Nzs5BTfE1jWEY=" crossorigin=""></script>
+  <script>
+    document.addEventListener('DOMContentLoaded', ()=>{
+      window.renderListingsUI?.('#listing-app');
+    });
+  </script>
+  <script defer src="/js/listings.data.js"></script>
+  <script defer src="/js/listings.render.js"></script>
+  <script defer src="/js/lightbox.js"></script>
+  <script defer src="/js/shortlist.js"></script>
+  <script defer src="/js/onepager.js"></script>
+  <script defer src="/js/forms.js"></script>
+  <script defer src="scripts/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add the Leaflet CDN assets alongside the existing stylesheet imports
- replace the static listings markup with a mount point and load the listings data/render bundles
- call the listings renderer after DOMContentLoaded so the dynamic cards and map can hydrate

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd6fa9e7e48327b162a91db85f267d