### PR TITLE
Prevent duplicate shortlist initialization

### DIFF
--- a/js/shortlist.js
+++ b/js/shortlist.js
@@ -2,6 +2,7 @@
 /*! shortlist.js — simple localStorage "saved listings" with ⭐ toggle */
 (function(){
   const KEY = 'shortlistV1';
+  let bound = false;
 
   function load(){ try{ return JSON.parse(localStorage.getItem(KEY))||{} }catch{ return {} } }
   function save(data){ localStorage.setItem(KEY, JSON.stringify(data)); }
@@ -84,7 +85,10 @@
   }
 
   function initShortlist(){
-    document.addEventListener('click', onClick);
+    if(!bound){
+      document.addEventListener('click', onClick);
+      bound = true;
+    }
     hydrate(); renderShortlist();
   }
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -462,4 +462,3 @@ I am an ' + v + ' interested in touring...'); }
       });
     })();
 
-    window.initShortlist?.();


### PR DESCRIPTION
## Summary
- add a guard flag in `js/shortlist.js` so the click handler only binds once
- remove the redundant eager shortlist initialization from `scripts/main.js`

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd75cfea708327914f403e6c041062