### PR TITLE
Improve mobile navigation responsiveness

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -100,6 +100,13 @@ nav a{ color: var(--ink-2); font-weight: 600; padding: .5rem .65rem; border-radi
 nav a[aria-current="true"]{ color: var(--primary); background: color-mix(in oklab, var(--primary) 10%, transparent); }
 nav a:focus-visible, button:focus-visible, input:focus-visible, select:focus-visible, textarea:focus-visible{ outline: 3px solid color-mix(in oklab, var(--primary) 35%, transparent); outline-offset: 2px; border-radius: var(--r-xs); }
 
+@media (max-width: 640px){
+  .nav{ flex-wrap: wrap; align-items: flex-start; }
+  .nav nav{ flex-basis: 100%; order: 3; margin-top: .75rem; }
+  .nav nav ul{ flex-wrap: wrap; gap: .75rem; justify-content: flex-start; }
+  #themeToggle{ order: 2; margin-left: auto; margin-top: .5rem; }
+}
+
 /* Carousel --------------------------------------------------------------- */
 .carousel{ position: relative; overflow: clip; border-bottom: 1px solid var(--line); }
 .carousel .slides{ display: grid; grid-auto-flow: column; grid-auto-columns: 100%; transition: transform .6s ease; }


### PR DESCRIPTION
## Summary
- add a mobile breakpoint that wraps the header navigation and aligns its contents for small screens
- adjust the nav list and theme toggle ordering so links wrap cleanly without overlapping

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd7d3f438c83279e627629d4814973