### PR TITLE
Use flex layout for section title pills

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -124,7 +124,7 @@ nav a:focus-visible, button:focus-visible, input:focus-visible, select:focus-vis
 section{ padding: clamp(1.25rem, 3vw, 2.25rem) 0; }
 .section-title{ display:flex; align-items:end; justify-content:space-between; gap: .75rem; margin-bottom: 1rem; }
 .section-title h2{ margin: 0; }
-.section-title .pill{ margin-left: .35rem; }
+.section-title > div{ display:flex; flex-wrap:wrap; gap: .5rem; row-gap: .4rem; }
 
 /* Grid & cards ----------------------------------------------------------- */
 .grid{ display:flex; flex-wrap: wrap; gap: 1rem; }


### PR DESCRIPTION
## Summary
- replace the margin-based spacing for section title pills with a flexbox layout
- allow pills to wrap with consistent horizontal and vertical gaps next to headings

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd99a413e483279f7b1e7b4daca4ca