### PR TITLE
Generate static listing detail pages from JSON inventory

### DIFF
--- a/IshwinderGhag-main/index.html
+++ b/IshwinderGhag-main/index.html
@@ -151,6 +151,7 @@
         <div class="section-title">
           <h2>Featured Listings</h2>
           <div><span class="pill">Land</span><span class="pill">Industrial</span><span class="pill">Investment</span></div>
+          <p class="small">Full detail pages: <a href="/listings/123/">123 Example Ave</a> • <a href="/listings/456/">456 Market Street</a> • <a href="/listings/789/">789 Industrial Way</a></p>
         </div>
         <div class="grid">
 

--- a/data/listings.json
+++ b/data/listings.json
@@ -1,0 +1,53 @@
+[
+  {
+    "id": "123",
+    "title": "123 Example Ave",
+    "type": "Residential",
+    "city": "Surrey",
+    "price": 1249900,
+    "priceDisplay": "$1,249,900",
+    "address": "123 Example Ave, Surrey, BC",
+    "coords": [49.1913, -122.849],
+    "cover": "/assets/listings/123/cover.jpg",
+    "webp": "/assets/listings/123/cover.webp",
+    "gallery": [
+      "/assets/listings/123/cover.jpg"
+    ],
+    "details": "4 bed • 3 bath • 2,100 sqft • Lot 4,000 sqft",
+    "badge": "New"
+  },
+  {
+    "id": "456",
+    "title": "456 Market Street",
+    "type": "Commercial",
+    "city": "Langley",
+    "price": 2190000,
+    "priceDisplay": "$2,190,000",
+    "address": "456 Market St, Langley, BC",
+    "coords": [49.1044, -122.6609],
+    "cover": "/assets/ishwinder/hero-1280.jpg",
+    "webp": "/assets/ishwinder/hero-1280.jpg",
+    "gallery": [
+      "/assets/ishwinder/hero-1280.jpg"
+    ],
+    "details": "Retail + Office • 5,800 sqft",
+    "badge": "Featured"
+  },
+  {
+    "id": "789",
+    "title": "789 Industrial Way",
+    "type": "Industrial",
+    "city": "Abbotsford",
+    "price": 3490000,
+    "priceDisplay": "$3,490,000",
+    "address": "789 Industrial Way, Abbotsford, BC",
+    "coords": [49.0504, -122.3045],
+    "cover": "/assets/ishwinder/hero-960.jpg",
+    "webp": "/assets/ishwinder/hero-960.jpg",
+    "gallery": [
+      "/assets/ishwinder/hero-960.jpg"
+    ],
+    "details": "Warehouse • 12,000 sqft • Clear height 26'",
+    "badge": "Hot"
+  }
+]

--- a/index.html
+++ b/index.html
@@ -147,6 +147,7 @@
         <div class="section-title">
           <h2>Featured Listings</h2>
           <div><span class="pill">Land</span><span class="pill">Industrial</span><span class="pill">Investment</span></div>
+          <p class="small">Full detail pages: <a href="/listings/123/">123 Example Ave</a> • <a href="/listings/456/">456 Market Street</a> • <a href="/listings/789/">789 Industrial Way</a></p>
         </div>
         <div class="grid">
 

--- a/js/listings.data.js
+++ b/js/listings.data.js
@@ -1,51 +1,25 @@
 
 /*! listings.data.js — single source of truth for properties */
-window.LISTINGS = [
-  {
-    id: "123",
-    title: "123 Example Ave",
-    type: "Residential",
-    city: "Surrey",
-    price: 1249900,
-    priceDisplay: "$1,249,900",
-    address: "123 Example Ave, Surrey, BC",
-    coords: [49.1913, -122.8490],
-    cover: "/assets/listings/123/cover.jpg",
-    webp: "/assets/listings/123/cover.webp",
-    gallery: [
-      "/assets/listings/123/cover.jpg"
-    ],
-    details: "4 bed • 3 bath • 2,100 sqft • Lot 4,000 sqft",
-    badge: "New"
-  },
-  {
-    id: "456",
-    title: "456 Market Street",
-    type: "Commercial",
-    city: "Langley",
-    price: 2190000,
-    priceDisplay: "$2,190,000",
-    address: "456 Market St, Langley, BC",
-    coords: [49.1044, -122.6609],
-    cover: "/assets/ishwinder/hero-1280.jpg",
-    webp: "/assets/ishwinder/hero-1280.jpg",
-    gallery: ["/assets/ishwinder/hero-1280.jpg"],
-    details: "Retail + Office • 5,800 sqft",
-    badge: "Featured"
-  },
-  {
-    id: "789",
-    title: "789 Industrial Way",
-    type: "Industrial",
-    city: "Abbotsford",
-    price: 3490000,
-    priceDisplay: "$3,490,000",
-    address: "789 Industrial Way, Abbotsford, BC",
-    coords: [49.0504, -122.3045],
-    cover: "/assets/ishwinder/hero-960.jpg",
-    webp: "/assets/ishwinder/hero-960.jpg",
-    gallery: ["/assets/ishwinder/hero-960.jpg"],
-    details: "Warehouse • 12,000 sqft • Clear height 26'",
-    badge: "Hot"
+(function(){
+  const SOURCE = '/data/listings.json';
+  window.LISTINGS = window.LISTINGS || [];
+
+  async function loadListings(){
+    try {
+      const res = await fetch(SOURCE, {cache: 'no-store'});
+      if(!res.ok) throw new Error(`Request failed: ${res.status}`);
+      const data = await res.json();
+      if(!Array.isArray(data)) throw new Error('Listings payload must be an array.');
+      window.LISTINGS = data;
+      window.dispatchEvent(new CustomEvent('listings:updated', {detail: data}));
+    } catch(err){
+      console.error('Failed to load listings inventory', err);
+    }
   }
-];
+
+  if(document.readyState === 'loading'){
+    document.addEventListener('DOMContentLoaded', loadListings, {once: true});
+  } else {
+    loadListings();
+  }
+})();

--- a/listings/123/index.html
+++ b/listings/123/index.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <title>123 Example Ave | Ishwinder Ghag Listings</title>
+  <meta name="description" content="4 bed • 3 bath • 2,100 sqft • Lot 4,000 sqft">
+  <link rel="canonical" href="https://ishwinderghag.com/listings/123/">
+  <meta property="og:type" content="article">
+  <meta property="og:title" content="123 Example Ave | Ishwinder Ghag">
+  <meta property="og:description" content="4 bed • 3 bath • 2,100 sqft • Lot 4,000 sqft">
+  <meta property="og:image" content="/assets/listings/123/cover.jpg">
+  <meta property="og:url" content="https://ishwinderghag.com/listings/123/">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="stylesheet" href="/styles/main.css">
+  <style>
+    .detail-hero{position:relative; border-radius:16px; overflow:hidden; margin-bottom:2rem;}
+    .detail-hero img{width:100%; height:auto; display:block;}
+    .detail-header{display:flex; flex-direction:column; gap:.75rem; margin-bottom:1.5rem;}
+    .gallery{display:grid; gap:1rem; grid-template-columns:repeat(auto-fit,minmax(240px,1fr));}
+    .gallery-item{border-radius:12px; overflow:hidden; background:#f5f5f5;}
+    .gallery-item img{width:100%; height:100%; object-fit:cover; display:block;}
+    .cta-group{display:flex; flex-wrap:wrap; gap:.75rem; margin-top:1rem;}
+  </style>
+</head>
+<body>
+  <a class="visually-hidden" href="#main">Skip to content</a>
+  <header class="container" style="padding-top:2rem;">
+    <a href="/" class="small">← Back to homepage</a>
+    <h1 class="m-0">123 Example Ave</h1>
+    <p class="small m-0">123 Example Ave, Surrey, BC</p>
+  </header>
+  <main id="main" class="container" style="padding-bottom:3rem;">
+    <div class="detail-hero">
+      <img src="/assets/listings/123/cover.jpg" alt="123 Example Ave" loading="eager">
+    </div>
+    <div class="detail-header">
+      <span class="pill">Residential • Surrey</span>
+      <div class="price" style="font-size:1.75rem; font-weight:600;">$1,249,900</div>
+      <p>4 bed • 3 bath • 2,100 sqft • Lot 4,000 sqft</p>
+      <div class="cta-group">
+        <a class="btn" href="mailto:ishwinderghag@gmail.com?subject=Inquiry%20about%20123%20Example%20Ave">Request more information</a>
+        <a class="btn ghost" href="tel:+16045374334">Call 604-537-4334</a>
+      </div>
+    </div>
+    
+    <div class="gallery">
+      
+        <figure class="gallery-item">
+          <img src="/assets/listings/123/cover.jpg" alt="123 Example Ave photo 1" loading="lazy">
+        </figure>
+      
+    </div>
+  
+    <section aria-labelledby="listing-facts" style="margin-top:2.5rem;">
+      <h2 id="listing-facts">Property details</h2>
+      <ul class="small" style="line-height:1.6; padding-left:1.25rem;">
+        <li>4 bed • 3 bath • 2,100 sqft • Lot 4,000 sqft</li>
+        <li>Status: New</li>
+        <li>City: Surrey</li>
+        <li>Type: Residential</li>
+        <li>Latitude: 49.1913, Longitude: -122.849</li>
+      </ul>
+    </section>
+  </main>
+  <footer class="container" style="padding-bottom:2rem;">
+    <p class="small">Royal LePage Global Force Realty • Ishwinder Ghag Personal Real Estate Corporation</p>
+  </footer>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"RealEstateListing","name":"123 Example Ave","description":"4 bed • 3 bath • 2,100 sqft • Lot 4,000 sqft","url":"https://ishwinderghag.com/listings/123/","image":["/assets/listings/123/cover.jpg"],"offers":{"@type":"Offer","price":1249900,"priceCurrency":"CAD"},"address":{"@type":"PostalAddress","streetAddress":"123 Example Ave, Surrey, BC","addressLocality":"Surrey","addressRegion":"BC","addressCountry":"CA"}}</script>
+</body>
+</html>

--- a/listings/456/index.html
+++ b/listings/456/index.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <title>456 Market Street | Ishwinder Ghag Listings</title>
+  <meta name="description" content="Retail + Office • 5,800 sqft">
+  <link rel="canonical" href="https://ishwinderghag.com/listings/456/">
+  <meta property="og:type" content="article">
+  <meta property="og:title" content="456 Market Street | Ishwinder Ghag">
+  <meta property="og:description" content="Retail + Office • 5,800 sqft">
+  <meta property="og:image" content="/assets/ishwinder/hero-1280.jpg">
+  <meta property="og:url" content="https://ishwinderghag.com/listings/456/">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="stylesheet" href="/styles/main.css">
+  <style>
+    .detail-hero{position:relative; border-radius:16px; overflow:hidden; margin-bottom:2rem;}
+    .detail-hero img{width:100%; height:auto; display:block;}
+    .detail-header{display:flex; flex-direction:column; gap:.75rem; margin-bottom:1.5rem;}
+    .gallery{display:grid; gap:1rem; grid-template-columns:repeat(auto-fit,minmax(240px,1fr));}
+    .gallery-item{border-radius:12px; overflow:hidden; background:#f5f5f5;}
+    .gallery-item img{width:100%; height:100%; object-fit:cover; display:block;}
+    .cta-group{display:flex; flex-wrap:wrap; gap:.75rem; margin-top:1rem;}
+  </style>
+</head>
+<body>
+  <a class="visually-hidden" href="#main">Skip to content</a>
+  <header class="container" style="padding-top:2rem;">
+    <a href="/" class="small">← Back to homepage</a>
+    <h1 class="m-0">456 Market Street</h1>
+    <p class="small m-0">456 Market St, Langley, BC</p>
+  </header>
+  <main id="main" class="container" style="padding-bottom:3rem;">
+    <div class="detail-hero">
+      <img src="/assets/ishwinder/hero-1280.jpg" alt="456 Market Street" loading="eager">
+    </div>
+    <div class="detail-header">
+      <span class="pill">Commercial • Langley</span>
+      <div class="price" style="font-size:1.75rem; font-weight:600;">$2,190,000</div>
+      <p>Retail + Office • 5,800 sqft</p>
+      <div class="cta-group">
+        <a class="btn" href="mailto:ishwinderghag@gmail.com?subject=Inquiry%20about%20456%20Market%20Street">Request more information</a>
+        <a class="btn ghost" href="tel:+16045374334">Call 604-537-4334</a>
+      </div>
+    </div>
+    
+    <div class="gallery">
+      
+        <figure class="gallery-item">
+          <img src="/assets/ishwinder/hero-1280.jpg" alt="456 Market Street photo 1" loading="lazy">
+        </figure>
+      
+    </div>
+  
+    <section aria-labelledby="listing-facts" style="margin-top:2.5rem;">
+      <h2 id="listing-facts">Property details</h2>
+      <ul class="small" style="line-height:1.6; padding-left:1.25rem;">
+        <li>Retail + Office • 5,800 sqft</li>
+        <li>Status: Featured</li>
+        <li>City: Langley</li>
+        <li>Type: Commercial</li>
+        <li>Latitude: 49.1044, Longitude: -122.6609</li>
+      </ul>
+    </section>
+  </main>
+  <footer class="container" style="padding-bottom:2rem;">
+    <p class="small">Royal LePage Global Force Realty • Ishwinder Ghag Personal Real Estate Corporation</p>
+  </footer>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"RealEstateListing","name":"456 Market Street","description":"Retail + Office • 5,800 sqft","url":"https://ishwinderghag.com/listings/456/","image":["/assets/ishwinder/hero-1280.jpg"],"offers":{"@type":"Offer","price":2190000,"priceCurrency":"CAD"},"address":{"@type":"PostalAddress","streetAddress":"456 Market St, Langley, BC","addressLocality":"Langley","addressRegion":"BC","addressCountry":"CA"}}</script>
+</body>
+</html>

--- a/listings/789/index.html
+++ b/listings/789/index.html
@@ -1,0 +1,71 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <title>789 Industrial Way | Ishwinder Ghag Listings</title>
+  <meta name="description" content="Warehouse • 12,000 sqft • Clear height 26'">
+  <link rel="canonical" href="https://ishwinderghag.com/listings/789/">
+  <meta property="og:type" content="article">
+  <meta property="og:title" content="789 Industrial Way | Ishwinder Ghag">
+  <meta property="og:description" content="Warehouse • 12,000 sqft • Clear height 26'">
+  <meta property="og:image" content="/assets/ishwinder/hero-960.jpg">
+  <meta property="og:url" content="https://ishwinderghag.com/listings/789/">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="stylesheet" href="/styles/main.css">
+  <style>
+    .detail-hero{position:relative; border-radius:16px; overflow:hidden; margin-bottom:2rem;}
+    .detail-hero img{width:100%; height:auto; display:block;}
+    .detail-header{display:flex; flex-direction:column; gap:.75rem; margin-bottom:1.5rem;}
+    .gallery{display:grid; gap:1rem; grid-template-columns:repeat(auto-fit,minmax(240px,1fr));}
+    .gallery-item{border-radius:12px; overflow:hidden; background:#f5f5f5;}
+    .gallery-item img{width:100%; height:100%; object-fit:cover; display:block;}
+    .cta-group{display:flex; flex-wrap:wrap; gap:.75rem; margin-top:1rem;}
+  </style>
+</head>
+<body>
+  <a class="visually-hidden" href="#main">Skip to content</a>
+  <header class="container" style="padding-top:2rem;">
+    <a href="/" class="small">← Back to homepage</a>
+    <h1 class="m-0">789 Industrial Way</h1>
+    <p class="small m-0">789 Industrial Way, Abbotsford, BC</p>
+  </header>
+  <main id="main" class="container" style="padding-bottom:3rem;">
+    <div class="detail-hero">
+      <img src="/assets/ishwinder/hero-960.jpg" alt="789 Industrial Way" loading="eager">
+    </div>
+    <div class="detail-header">
+      <span class="pill">Industrial • Abbotsford</span>
+      <div class="price" style="font-size:1.75rem; font-weight:600;">$3,490,000</div>
+      <p>Warehouse • 12,000 sqft • Clear height 26'</p>
+      <div class="cta-group">
+        <a class="btn" href="mailto:ishwinderghag@gmail.com?subject=Inquiry%20about%20789%20Industrial%20Way">Request more information</a>
+        <a class="btn ghost" href="tel:+16045374334">Call 604-537-4334</a>
+      </div>
+    </div>
+    
+    <div class="gallery">
+      
+        <figure class="gallery-item">
+          <img src="/assets/ishwinder/hero-960.jpg" alt="789 Industrial Way photo 1" loading="lazy">
+        </figure>
+      
+    </div>
+  
+    <section aria-labelledby="listing-facts" style="margin-top:2.5rem;">
+      <h2 id="listing-facts">Property details</h2>
+      <ul class="small" style="line-height:1.6; padding-left:1.25rem;">
+        <li>Warehouse • 12,000 sqft • Clear height 26'</li>
+        <li>Status: Hot</li>
+        <li>City: Abbotsford</li>
+        <li>Type: Industrial</li>
+        <li>Latitude: 49.0504, Longitude: -122.3045</li>
+      </ul>
+    </section>
+  </main>
+  <footer class="container" style="padding-bottom:2rem;">
+    <p class="small">Royal LePage Global Force Realty • Ishwinder Ghag Personal Real Estate Corporation</p>
+  </footer>
+  <script type="application/ld+json">{"@context":"https://schema.org","@type":"RealEstateListing","name":"789 Industrial Way","description":"Warehouse • 12,000 sqft • Clear height 26'","url":"https://ishwinderghag.com/listings/789/","image":["/assets/ishwinder/hero-960.jpg"],"offers":{"@type":"Offer","price":3490000,"priceCurrency":"CAD"},"address":{"@type":"PostalAddress","streetAddress":"789 Industrial Way, Abbotsford, BC","addressLocality":"Abbotsford","addressRegion":"BC","addressCountry":"CA"}}</script>
+</body>
+</html>

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,4 @@
 [build]
-  command = ""
+  command = "npm run build"
   publish = "."
   functions = "api"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node api/contact.js",
-    "build": "echo \"No build step specified\""
+    "build:listings": "node scripts/build-listings.js",
+    "build": "npm run build:listings"
   },
   "keywords": [],
   "author": "",

--- a/public/api/listings/123.json
+++ b/public/api/listings/123.json
@@ -1,0 +1,21 @@
+{
+  "id": "123",
+  "title": "123 Example Ave",
+  "type": "Residential",
+  "city": "Surrey",
+  "price": 1249900,
+  "priceDisplay": "$1,249,900",
+  "address": "123 Example Ave, Surrey, BC",
+  "coords": [
+    49.1913,
+    -122.849
+  ],
+  "cover": "/assets/listings/123/cover.jpg",
+  "webp": "/assets/listings/123/cover.webp",
+  "gallery": [
+    "/assets/listings/123/cover.jpg"
+  ],
+  "details": "4 bed • 3 bath • 2,100 sqft • Lot 4,000 sqft",
+  "badge": "New",
+  "generatedAt": "2025-10-01T22:04:41.299Z"
+}

--- a/public/api/listings/456.json
+++ b/public/api/listings/456.json
@@ -1,0 +1,21 @@
+{
+  "id": "456",
+  "title": "456 Market Street",
+  "type": "Commercial",
+  "city": "Langley",
+  "price": 2190000,
+  "priceDisplay": "$2,190,000",
+  "address": "456 Market St, Langley, BC",
+  "coords": [
+    49.1044,
+    -122.6609
+  ],
+  "cover": "/assets/ishwinder/hero-1280.jpg",
+  "webp": "/assets/ishwinder/hero-1280.jpg",
+  "gallery": [
+    "/assets/ishwinder/hero-1280.jpg"
+  ],
+  "details": "Retail + Office • 5,800 sqft",
+  "badge": "Featured",
+  "generatedAt": "2025-10-01T22:04:41.299Z"
+}

--- a/public/api/listings/789.json
+++ b/public/api/listings/789.json
@@ -1,0 +1,21 @@
+{
+  "id": "789",
+  "title": "789 Industrial Way",
+  "type": "Industrial",
+  "city": "Abbotsford",
+  "price": 3490000,
+  "priceDisplay": "$3,490,000",
+  "address": "789 Industrial Way, Abbotsford, BC",
+  "coords": [
+    49.0504,
+    -122.3045
+  ],
+  "cover": "/assets/ishwinder/hero-960.jpg",
+  "webp": "/assets/ishwinder/hero-960.jpg",
+  "gallery": [
+    "/assets/ishwinder/hero-960.jpg"
+  ],
+  "details": "Warehouse • 12,000 sqft • Clear height 26'",
+  "badge": "Hot",
+  "generatedAt": "2025-10-01T22:04:41.299Z"
+}

--- a/public/api/listings/index.json
+++ b/public/api/listings/index.json
@@ -1,0 +1,65 @@
+{
+  "generatedAt": "2025-10-01T22:04:41.299Z",
+  "listings": [
+    {
+      "id": "123",
+      "title": "123 Example Ave",
+      "type": "Residential",
+      "city": "Surrey",
+      "price": 1249900,
+      "priceDisplay": "$1,249,900",
+      "address": "123 Example Ave, Surrey, BC",
+      "coords": [
+        49.1913,
+        -122.849
+      ],
+      "cover": "/assets/listings/123/cover.jpg",
+      "webp": "/assets/listings/123/cover.webp",
+      "gallery": [
+        "/assets/listings/123/cover.jpg"
+      ],
+      "details": "4 bed • 3 bath • 2,100 sqft • Lot 4,000 sqft",
+      "badge": "New"
+    },
+    {
+      "id": "456",
+      "title": "456 Market Street",
+      "type": "Commercial",
+      "city": "Langley",
+      "price": 2190000,
+      "priceDisplay": "$2,190,000",
+      "address": "456 Market St, Langley, BC",
+      "coords": [
+        49.1044,
+        -122.6609
+      ],
+      "cover": "/assets/ishwinder/hero-1280.jpg",
+      "webp": "/assets/ishwinder/hero-1280.jpg",
+      "gallery": [
+        "/assets/ishwinder/hero-1280.jpg"
+      ],
+      "details": "Retail + Office • 5,800 sqft",
+      "badge": "Featured"
+    },
+    {
+      "id": "789",
+      "title": "789 Industrial Way",
+      "type": "Industrial",
+      "city": "Abbotsford",
+      "price": 3490000,
+      "priceDisplay": "$3,490,000",
+      "address": "789 Industrial Way, Abbotsford, BC",
+      "coords": [
+        49.0504,
+        -122.3045
+      ],
+      "cover": "/assets/ishwinder/hero-960.jpg",
+      "webp": "/assets/ishwinder/hero-960.jpg",
+      "gallery": [
+        "/assets/ishwinder/hero-960.jpg"
+      ],
+      "details": "Warehouse • 12,000 sqft • Clear height 26'",
+      "badge": "Hot"
+    }
+  ]
+}

--- a/scripts/build-listings.js
+++ b/scripts/build-listings.js
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+const fs = require('fs/promises');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const DATA_PATH = path.join(ROOT, 'data', 'listings.json');
+const LISTINGS_DIR = path.join(ROOT, 'listings');
+const API_DIR = path.join(ROOT, 'public', 'api', 'listings');
+
+function formatCurrency(amount, currencyDisplay){
+  if(currencyDisplay) return currencyDisplay;
+  if(typeof amount !== 'number') return '';
+  return new Intl.NumberFormat('en-CA', {
+    style: 'currency',
+    currency: 'CAD',
+    maximumFractionDigits: 0
+  }).format(amount);
+}
+
+function listingDescription(listing){
+  if(listing.details) return listing.details;
+  return `${listing.type||'Property'} in ${listing.city||'British Columbia'}`;
+}
+
+function renderGallery(listing){
+  const gallery = Array.isArray(listing.gallery) ? listing.gallery : [];
+  if(!gallery.length) return '';
+  return `
+    <div class="gallery">
+      ${gallery.map((src, idx)=>`
+        <figure class="gallery-item">
+          <img src="${src}" alt="${listing.title} photo ${idx+1}" loading="lazy">
+        </figure>
+      `).join('')}
+    </div>
+  `;
+}
+
+function renderHtml(listing){
+  const price = formatCurrency(listing.price, listing.priceDisplay);
+  const description = listingDescription(listing);
+  const canonical = `https://ishwinderghag.com/listings/${listing.id}/`;
+  const hero = listing.cover || (listing.gallery && listing.gallery[0]) || '/assets/ishwinder/hero-1280.jpg';
+  const galleryMarkup = renderGallery(listing);
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'RealEstateListing',
+    'name': listing.title,
+    'description': description,
+    'url': canonical,
+    'image': galleryMarkup ? (listing.gallery || []) : [hero],
+    'offers': {
+      '@type': 'Offer',
+      'price': listing.price,
+      'priceCurrency': 'CAD'
+    },
+    'address': {
+      '@type': 'PostalAddress',
+      'streetAddress': listing.address,
+      'addressLocality': listing.city,
+      'addressRegion': 'BC',
+      'addressCountry': 'CA'
+    }
+  };
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+  <title>${listing.title} | Ishwinder Ghag Listings</title>
+  <meta name="description" content="${description}">
+  <link rel="canonical" href="${canonical}">
+  <meta property="og:type" content="article">
+  <meta property="og:title" content="${listing.title} | Ishwinder Ghag">
+  <meta property="og:description" content="${description}">
+  <meta property="og:image" content="${hero}">
+  <meta property="og:url" content="${canonical}">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="stylesheet" href="/styles/main.css">
+  <style>
+    .detail-hero{position:relative; border-radius:16px; overflow:hidden; margin-bottom:2rem;}
+    .detail-hero img{width:100%; height:auto; display:block;}
+    .detail-header{display:flex; flex-direction:column; gap:.75rem; margin-bottom:1.5rem;}
+    .gallery{display:grid; gap:1rem; grid-template-columns:repeat(auto-fit,minmax(240px,1fr));}
+    .gallery-item{border-radius:12px; overflow:hidden; background:#f5f5f5;}
+    .gallery-item img{width:100%; height:100%; object-fit:cover; display:block;}
+    .cta-group{display:flex; flex-wrap:wrap; gap:.75rem; margin-top:1rem;}
+  </style>
+</head>
+<body>
+  <a class="visually-hidden" href="#main">Skip to content</a>
+  <header class="container" style="padding-top:2rem;">
+    <a href="/" class="small">← Back to homepage</a>
+    <h1 class="m-0">${listing.title}</h1>
+    <p class="small m-0">${listing.address || ''}</p>
+  </header>
+  <main id="main" class="container" style="padding-bottom:3rem;">
+    <div class="detail-hero">
+      <img src="${hero}" alt="${listing.title}" loading="eager">
+    </div>
+    <div class="detail-header">
+      <span class="pill">${listing.type || 'Property'} • ${listing.city || ''}</span>
+      <div class="price" style="font-size:1.75rem; font-weight:600;">${price}</div>
+      <p>${description}</p>
+      <div class="cta-group">
+        <a class="btn" href="mailto:ishwinderghag@gmail.com?subject=${encodeURIComponent('Inquiry about ' + listing.title)}">Request more information</a>
+        <a class="btn ghost" href="tel:+16045374334">Call 604-537-4334</a>
+      </div>
+    </div>
+    ${galleryMarkup}
+    <section aria-labelledby="listing-facts" style="margin-top:2.5rem;">
+      <h2 id="listing-facts">Property details</h2>
+      <ul class="small" style="line-height:1.6; padding-left:1.25rem;">
+        ${listing.details ? `<li>${listing.details}</li>` : ''}
+        ${listing.badge ? `<li>Status: ${listing.badge}</li>` : ''}
+        <li>City: ${listing.city || '—'}</li>
+        <li>Type: ${listing.type || '—'}</li>
+        ${listing.coords ? `<li>Latitude: ${listing.coords[0]}, Longitude: ${listing.coords[1]}</li>` : ''}
+      </ul>
+    </section>
+  </main>
+  <footer class="container" style="padding-bottom:2rem;">
+    <p class="small">Royal LePage Global Force Realty • Ishwinder Ghag Personal Real Estate Corporation</p>
+  </footer>
+  <script type="application/ld+json">${JSON.stringify(jsonLd)}</script>
+</body>
+</html>`;
+}
+
+async function ensureDir(dir){
+  await fs.mkdir(dir, {recursive: true});
+}
+
+async function build(){
+  const raw = await fs.readFile(DATA_PATH, 'utf8');
+  const listings = JSON.parse(raw);
+  if(!Array.isArray(listings)){
+    throw new Error('Expected an array of listings');
+  }
+
+  await fs.rm(LISTINGS_DIR, {recursive: true, force: true});
+  await fs.rm(API_DIR, {recursive: true, force: true});
+  await ensureDir(LISTINGS_DIR);
+  await ensureDir(API_DIR);
+
+  const timestamp = new Date().toISOString();
+
+  for(const listing of listings){
+    if(!listing.id) continue;
+    const dir = path.join(LISTINGS_DIR, listing.id);
+    await ensureDir(dir);
+    const htmlPath = path.join(dir, 'index.html');
+    await fs.writeFile(htmlPath, renderHtml(listing));
+
+    const apiPath = path.join(API_DIR, `${listing.id}.json`);
+    const payload = {...listing, generatedAt: timestamp};
+    await fs.writeFile(apiPath, JSON.stringify(payload, null, 2));
+  }
+
+  const indexPath = path.join(API_DIR, 'index.json');
+  await fs.writeFile(indexPath, JSON.stringify({generatedAt: timestamp, listings}, null, 2));
+
+  console.log(`Generated ${listings.length} listing page(s).`);
+}
+
+build().catch(err => {
+  console.error(err);
+  process.exitCode = 1;
+});

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,14 +2,32 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://your-domain.example/</loc>
-    <lastmod>2025-08-24</lastmod>
+    <lastmod>2025-10-01</lastmod>
     <priority>1.0</priority>
   </url>
 
   <url>
     <loc>https://your-domain.example/thanks.html</loc>
-    <lastmod>2025-08-24</lastmod>
+    <lastmod>2025-10-01</lastmod>
     <priority>0.4</priority>
+  </url>
+
+  <url>
+    <loc>https://your-domain.example/listings/123/</loc>
+    <lastmod>2025-10-01</lastmod>
+    <priority>0.6</priority>
+  </url>
+
+  <url>
+    <loc>https://your-domain.example/listings/456/</loc>
+    <lastmod>2025-10-01</lastmod>
+    <priority>0.6</priority>
+  </url>
+
+  <url>
+    <loc>https://your-domain.example/listings/789/</loc>
+    <lastmod>2025-10-01</lastmod>
+    <priority>0.6</priority>
   </url>
 
 </urlset>


### PR DESCRIPTION
## Summary
- move listing data into a reusable JSON module and load it on the client
- add a Node-based generator that emits listing detail HTML and API payloads and hook it into the build
- update UI links, navigation, and sitemap to surface the new detail routes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dda463b4ec832787cd530325e35ab4