### PR TITLE
Add CRM and scheduling integrations to contact form controller

### DIFF
--- a/api/contact.js
+++ b/api/contact.js
@@ -1,88 +1,492 @@
 const qs = require('querystring');
 const sanitizeHtml = require('sanitize-html');
 const sgMail = require('@sendgrid/mail');
+const fetch = require('node-fetch');
+const crypto = require('crypto');
 
-const { SENDGRID_API_KEY, CONTACT_RECIPIENT_EMAIL, CONTACT_FROM_EMAIL } = process.env;
+const {
+  SENDGRID_API_KEY,
+  CONTACT_RECIPIENT_EMAIL,
+  CONTACT_FROM_EMAIL,
+  CONTACT_REPLY_TO_EMAIL,
+  SENDGRID_TEMPLATE_MAP,
+  SENDGRID_DEFAULT_TEMPLATE_ID,
+  CRM_API_URL,
+  CRM_API_KEY,
+  LEAD_WEBHOOK_URL,
+  MEETING_INTENT_CONFIG,
+  CALENDLY_API_TOKEN,
+  SAVVYCAL_API_TOKEN,
+  SUPABASE_URL,
+  SUPABASE_SERVICE_ROLE_KEY,
+  SUPABASE_TABLE,
+  NETLIFY_KV_REST_API_URL,
+  NETLIFY_KV_REST_TOKEN,
+  NETLIFY_KV_NAMESPACE
+} = process.env;
 
 if (SENDGRID_API_KEY) {
   sgMail.setApiKey(SENDGRID_API_KEY);
 }
 
-const sanitize = (str) => sanitizeHtml(str, { allowedTags: [], allowedAttributes: {} });
+const baseHeaders = {
+  'Content-Type': 'application/json',
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'POST,OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type'
+};
 
-exports.handler = async (event) => {
-  const headers = {
-    'Content-Type': 'application/json',
-    'Access-Control-Allow-Origin': '*',
-    'Access-Control-Allow-Methods': 'POST,OPTIONS',
-    'Access-Control-Allow-Headers': 'Content-Type'
+const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const templateMap = safeJsonParse(SENDGRID_TEMPLATE_MAP) || {};
+const meetingConfig = safeJsonParse(MEETING_INTENT_CONFIG) || {};
+
+function safeJsonParse(value) {
+  if (!value) return null;
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    console.error('Failed to parse JSON configuration', { value, error: error.message });
+    return null;
+  }
+}
+
+function sanitizeText(value) {
+  if (value == null) return '';
+  return sanitizeHtml(String(value), { allowedTags: [], allowedAttributes: {} }).trim();
+}
+
+function sanitizeArray(value) {
+  if (!value) return [];
+  if (Array.isArray(value)) {
+    return value.map((entry) => sanitizeText(entry)).filter(Boolean);
+  }
+  if (typeof value === 'string') {
+    const trimmed = sanitizeText(value);
+    if (!trimmed) return [];
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (Array.isArray(parsed)) {
+        return parsed.map((entry) => sanitizeText(entry)).filter(Boolean);
+      }
+    } catch (err) {
+      // fall through to split
+    }
+    return trimmed
+      .split(',')
+      .map((entry) => sanitizeText(entry))
+      .filter(Boolean);
+  }
+  return [];
+}
+
+function sanitizeCalculators(rawCalculators) {
+  if (!rawCalculators) return {};
+  let source = rawCalculators;
+  if (typeof rawCalculators === 'string') {
+    try {
+      source = JSON.parse(rawCalculators);
+    } catch (error) {
+      console.warn('Unable to parse calculators payload', error.message);
+      return {};
+    }
+  }
+  if (typeof source !== 'object' || Array.isArray(source)) return {};
+  return Object.entries(source).reduce((acc, [key, value]) => {
+    const cleanKey = sanitizeText(key);
+    if (!cleanKey) return acc;
+    const numericValue = typeof value === 'number' ? value : parseFloat(String(value).replace(/[^0-9.-]/g, ''));
+    if (!Number.isNaN(numericValue)) {
+      acc[cleanKey] = numericValue;
+    }
+    return acc;
+  }, {});
+}
+
+function buildPayload(data = {}) {
+  const sanitized = {
+    name: sanitizeText(data.name),
+    email: sanitizeText(data.email).toLowerCase(),
+    phone: sanitizeText(data.phone),
+    message: sanitizeText(data.message),
+    intent: sanitizeText(data.intent || data.contextIntent),
+    shortlist: sanitizeArray(data.shortlist || data.shortlistIds),
+    calculators: sanitizeCalculators(data.calculators || data.calculatorData),
+    meta: {}
   };
 
+  const optionalFields = [
+    'company',
+    'timeline',
+    'budget',
+    'location',
+    'bedrooms',
+    'bathrooms',
+    'preferredContact',
+    'source'
+  ];
+
+  optionalFields.forEach((field) => {
+    const value = sanitizeText(data[field]);
+    if (value) sanitized.meta[field] = value;
+  });
+
+  sanitized.createdAt = new Date().toISOString();
+  sanitized.shortlist = Array.from(new Set(sanitized.shortlist));
+  return sanitized;
+}
+
+function validatePayload(payload) {
+  if (!payload.name) {
+    return 'Name is required';
+  }
+  if (!payload.email || !emailRegex.test(payload.email)) {
+    return 'A valid email is required';
+  }
+  if (!payload.message) {
+    return 'Message is required';
+  }
+  return null;
+}
+
+function getTemplateId(intent) {
+  if (intent && templateMap[intent]) return templateMap[intent];
+  if (templateMap.default) return templateMap.default;
+  return SENDGRID_DEFAULT_TEMPLATE_ID;
+}
+
+async function sendEmail(payload, schedulingInfo) {
+  if (!SENDGRID_API_KEY || !CONTACT_RECIPIENT_EMAIL || !CONTACT_FROM_EMAIL) {
+    throw new Error('Email configuration is incomplete');
+  }
+
+  const templateId = getTemplateId(payload.intent);
+  if (!templateId) {
+    throw new Error('No SendGrid template configured for this intent');
+  }
+
+  const recipients = CONTACT_RECIPIENT_EMAIL.split(',')
+    .map((addr) => sanitizeText(addr))
+    .filter(Boolean);
+
+  if (!recipients.length) {
+    throw new Error('No valid recipient configured');
+  }
+
+  const msg = {
+    to: recipients,
+    from: CONTACT_FROM_EMAIL,
+    templateId,
+    dynamicTemplateData: {
+      name: payload.name,
+      email: payload.email,
+      phone: payload.phone,
+      message: payload.message,
+      intent: payload.intent || 'general',
+      shortlist: payload.shortlist,
+      calculators: payload.calculators,
+      meta: payload.meta,
+      submitted_at: payload.createdAt,
+      scheduling_link: schedulingInfo?.url || null,
+      scheduling_label: schedulingInfo?.label || null
+    }
+  };
+
+  if (CONTACT_REPLY_TO_EMAIL) {
+    msg.replyTo = sanitizeText(CONTACT_REPLY_TO_EMAIL);
+  }
+
+  await sgMail.send(msg);
+}
+
+async function syncCrm(payload) {
+  if (!CRM_API_URL) return;
+  try {
+    const res = await fetch(CRM_API_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(CRM_API_KEY ? { Authorization: `Bearer ${CRM_API_KEY}` } : {})
+      },
+      body: JSON.stringify({
+        contact: {
+          name: payload.name,
+          email: payload.email,
+          phone: payload.phone
+        },
+        intent: payload.intent,
+        shortlistIds: payload.shortlist,
+        calculators: payload.calculators,
+        message: payload.message,
+        metadata: payload.meta,
+        submittedAt: payload.createdAt
+      })
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`CRM responded with ${res.status}: ${text}`);
+    }
+  } catch (error) {
+    console.error('CRM sync failed', error);
+  }
+}
+
+async function postLeadWebhook(payload, schedulingInfo) {
+  if (!LEAD_WEBHOOK_URL) return;
+  try {
+    const lines = [
+      `New contact submission`,
+      `• Name: ${payload.name}`,
+      `• Email: ${payload.email}`,
+      payload.phone ? `• Phone: ${payload.phone}` : null,
+      payload.intent ? `• Intent: ${payload.intent}` : null,
+      payload.shortlist.length ? `• Shortlist: ${payload.shortlist.join(', ')}` : null,
+      payload.message ? `• Message: ${payload.message}` : null,
+      schedulingInfo?.url ? `• Scheduling: ${schedulingInfo.url}` : null
+    ].filter(Boolean);
+
+    await fetch(LEAD_WEBHOOK_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text: lines.join('\n') })
+    });
+  } catch (error) {
+    console.error('Lead webhook failed', error);
+  }
+}
+
+function sanitizeCtas(ctas) {
+  if (!Array.isArray(ctas)) return [];
+  return ctas
+    .map((cta) => {
+      if (!cta || typeof cta !== 'object') return null;
+      const label = sanitizeText(cta.label);
+      const href = sanitizeText(cta.href);
+      if (!label || !href) return null;
+      return { label, href };
+    })
+    .filter(Boolean);
+}
+
+async function requestSchedulingLink(intent, payload) {
+  const config = intent ? meetingConfig[intent] : null;
+  if (!config) {
+    return { url: null, label: null, alternateCtas: [] };
+  }
+
+  const alternateCtas = sanitizeCtas(config.alternateCtas || []);
+  const defaultLabel = sanitizeText(config.label) || 'Schedule time';
+
+  try {
+    if (config.provider === 'calendly') {
+      if (!CALENDLY_API_TOKEN || !config.eventType) throw new Error('Calendly not configured');
+      const res = await fetch('https://api.calendly.com/scheduling_links', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${CALENDLY_API_TOKEN}`
+        },
+        body: JSON.stringify({
+          event_type: config.eventType,
+          max_event_count: 1,
+          invitee: {
+            email: payload.email,
+            name: payload.name
+          }
+        })
+      });
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(`Calendly responded with ${res.status}: ${text}`);
+      }
+      const json = await res.json();
+      const url = json?.resource?.booking_url || json?.resource?.scheduling_url;
+      if (url) {
+        return { url, label: defaultLabel, alternateCtas };
+      }
+    } else if (config.provider === 'savvycal') {
+      if (!SAVVYCAL_API_TOKEN || !config.link) throw new Error('SavvyCal not configured');
+      const res = await fetch(`https://api.savvycal.com/v1/links/${encodeURIComponent(config.link)}/personalized`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${SAVVYCAL_API_TOKEN}`
+        },
+        body: JSON.stringify({
+          invitee: {
+            name: payload.name,
+            email: payload.email
+          }
+        })
+      });
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(`SavvyCal responded with ${res.status}: ${text}`);
+      }
+      const json = await res.json();
+      const url = json?.data?.url || json?.data?.link || json?.link;
+      if (url) {
+        return { url, label: defaultLabel, alternateCtas };
+      }
+    }
+  } catch (error) {
+    console.error('Scheduling link request failed', error);
+  }
+
+  return { url: null, label: defaultLabel, alternateCtas };
+}
+
+function buildPersistenceRecord(payload, schedulingInfo) {
+  return {
+    id: crypto.randomUUID ? crypto.randomUUID() : `${Date.now()}-${Math.random().toString(16).slice(2)}`,
+    name: payload.name,
+    email: payload.email,
+    phone: payload.phone,
+    intent: payload.intent,
+    shortlist: payload.shortlist,
+    calculators: payload.calculators,
+    message: payload.message,
+    metadata: payload.meta,
+    scheduling_link: schedulingInfo?.url || null,
+    submitted_at: payload.createdAt
+  };
+}
+
+async function persistSubmission(payload, schedulingInfo) {
+  const record = buildPersistenceRecord(payload, schedulingInfo);
+
+  if (SUPABASE_URL && SUPABASE_SERVICE_ROLE_KEY) {
+    try {
+      const table = SUPABASE_TABLE || 'contact_submissions';
+      const res = await fetch(`${SUPABASE_URL.replace(/\/$/, '')}/rest/v1/${table}`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          apikey: SUPABASE_SERVICE_ROLE_KEY,
+          Authorization: `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
+          Prefer: 'return=minimal'
+        },
+        body: JSON.stringify(record)
+      });
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(`Supabase responded with ${res.status}: ${text}`);
+      }
+      return;
+    } catch (error) {
+      console.error('Supabase persistence failed', error);
+    }
+  }
+
+  if (NETLIFY_KV_REST_API_URL && NETLIFY_KV_REST_TOKEN && NETLIFY_KV_NAMESPACE) {
+    try {
+      const key = `contact:${record.id}`;
+      const url = `${NETLIFY_KV_REST_API_URL.replace(/\/$/, '')}/${encodeURIComponent(NETLIFY_KV_NAMESPACE)}/${encodeURIComponent(key)}`;
+      const res = await fetch(url, {
+        method: 'PUT',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${NETLIFY_KV_REST_TOKEN}`
+        },
+        body: JSON.stringify(record)
+      });
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(`Netlify KV responded with ${res.status}: ${text}`);
+      }
+    } catch (error) {
+      console.error('Netlify KV persistence failed', error);
+    }
+  }
+}
+
+exports.handler = async (event) => {
   if (event.httpMethod === 'OPTIONS') {
-    return { statusCode: 200, headers };
+    return { statusCode: 200, headers: baseHeaders };
   }
 
   if (event.httpMethod !== 'POST') {
-    return { statusCode: 405, headers, body: JSON.stringify({ success: false, error: 'Method Not Allowed' }) };
+    return {
+      statusCode: 405,
+      headers: baseHeaders,
+      body: JSON.stringify({ success: false, error: 'Method Not Allowed' })
+    };
   }
 
   try {
-    let data;
     const contentType = event.headers['content-type'] || '';
     const rawBody = event.body || '';
-    const body = event.isBase64Encoded
+    const decodedBody = event.isBase64Encoded
       ? Buffer.from(rawBody, 'base64').toString('utf8')
       : rawBody;
 
-    if (contentType.includes('application/json')) {
-      data = JSON.parse(body || '{}');
-    } else {
-      data = qs.parse(body || '');
-    }
+    const data = contentType.includes('application/json')
+      ? JSON.parse(decodedBody || '{}')
+      : qs.parse(decodedBody || '');
 
-    const name = sanitize(data.name);
-    const email = sanitize(data.email);
-    const message = sanitize(data.message);
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-
-    if (!name || !emailRegex.test(email) || !message) {
-      return { statusCode: 400, headers, body: JSON.stringify({ success: false, error: 'Invalid input' }) };
+    const payload = buildPayload(data);
+    const validationError = validatePayload(payload);
+    if (validationError) {
+      return {
+        statusCode: 400,
+        headers: baseHeaders,
+        body: JSON.stringify({ success: false, error: validationError })
+      };
     }
 
     if (!SENDGRID_API_KEY || !CONTACT_RECIPIENT_EMAIL || !CONTACT_FROM_EMAIL) {
       console.error('Missing email configuration. Ensure SENDGRID_API_KEY, CONTACT_RECIPIENT_EMAIL, and CONTACT_FROM_EMAIL are set.');
       return {
         statusCode: 500,
-        headers,
+        headers: baseHeaders,
         body: JSON.stringify({ success: false, error: 'Email service is not configured.' })
       };
     }
 
-    const recipients = CONTACT_RECIPIENT_EMAIL.split(',').map((addr) => addr.trim()).filter(Boolean);
-    const msg = {
-      to: recipients,
-      from: CONTACT_FROM_EMAIL,
-      subject: 'New contact form submission',
-      text: `Name: ${name}\nEmail: ${email}\nMessage:\n${message}`,
-      html: `<p><strong>Name:</strong> ${name}</p><p><strong>Email:</strong> ${email}</p><p><strong>Message:</strong><br>${message.replace(/\n/g, '<br>')}</p>`
-    };
+    const schedulingInfo = await requestSchedulingLink(payload.intent, payload);
 
     try {
-      await sgMail.send(msg);
+      await sendEmail(payload, schedulingInfo);
     } catch (sendError) {
       console.error('Failed to deliver contact form submission.', sendError);
       const providerMessage = sendError?.response?.body?.errors?.map((e) => e.message).join(' ') || sendError.message;
       return {
         statusCode: 502,
-        headers,
+        headers: baseHeaders,
         body: JSON.stringify({ success: false, error: `Delivery failed: ${providerMessage || 'Unknown error.'}` })
       };
     }
 
-    console.log('Contact form submission delivered:', { name, email, message });
-    return { statusCode: 200, headers, body: JSON.stringify({ success: true }) };
-  } catch (err) {
-    console.error(err);
-    return { statusCode: 500, headers, body: JSON.stringify({ success: false, error: 'Server error' }) };
+    await Promise.allSettled([
+      syncCrm(payload),
+      postLeadWebhook(payload, schedulingInfo),
+      persistSubmission(payload, schedulingInfo)
+    ]);
+
+    console.log('Contact form submission delivered:', {
+      name: payload.name,
+      email: payload.email,
+      intent: payload.intent,
+      shortlist: payload.shortlist,
+      calculators: payload.calculators
+    });
+
+    return {
+      statusCode: 200,
+      headers: baseHeaders,
+      body: JSON.stringify({
+        success: true,
+        intent: payload.intent,
+        schedulingLink: schedulingInfo?.url || null,
+        schedulingLabel: schedulingInfo?.label || null,
+        alternateCtas: schedulingInfo?.alternateCtas || []
+      })
+    };
+  } catch (error) {
+    console.error(error);
+    return {
+      statusCode: 500,
+      headers: baseHeaders,
+      body: JSON.stringify({ success: false, error: 'Server error' })
+    };
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@sendgrid/mail": "^8.1.6",
+        "node-fetch": "^2.7.0",
         "sanitize-html": "^2.17.0"
       }
     },
@@ -458,6 +459,26 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/parse-srcset": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
@@ -525,6 +546,28 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "type": "commonjs",
   "dependencies": {
     "@sendgrid/mail": "^8.1.6",
+    "node-fetch": "^2.7.0",
     "sanitize-html": "^2.17.0"
   }
 }

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -447,7 +447,39 @@ I am an ' + v + ' interested in touring...'); }
           });
           const json = await res.json();
           if(json.success){
-            result.textContent = 'Message sent successfully.';
+            result.textContent = '';
+            const schedulingLink = json.schedulingLink;
+            const schedulingLabel = json.schedulingLabel || 'Schedule a meeting';
+            const alternateCtas = Array.isArray(json.alternateCtas) ? json.alternateCtas : [];
+
+            if(schedulingLink){
+              const lead = document.createElement('span');
+              lead.textContent = 'Thanks! You can '; lead.className = 'cta-lead';
+              const link = document.createElement('a');
+              link.href = schedulingLink;
+              link.target = '_blank';
+              link.rel = 'noopener noreferrer';
+              link.textContent = schedulingLabel;
+              result.append(lead, link, document.createTextNode(' to find time on my calendar.'));
+            } else if(alternateCtas.length){
+              const lead = document.createElement('p');
+              lead.textContent = 'Message sent! While you wait, here are a few next steps:';
+              const list = document.createElement('ul');
+              alternateCtas.forEach((cta)=>{
+                if(!cta || !cta.href || !cta.label) return;
+                const item = document.createElement('li');
+                const link = document.createElement('a');
+                link.href = cta.href;
+                link.target = '_blank';
+                link.rel = 'noopener noreferrer';
+                link.textContent = cta.label;
+                item.appendChild(link);
+                list.appendChild(item);
+              });
+              result.append(lead, list);
+            } else {
+              result.textContent = 'Message sent successfully.';
+            }
             form.reset();
           }else{
             throw new Error(json.error||'Error');


### PR DESCRIPTION
## Summary
- refactor the contact serverless function into a richer controller that sanitizes/enriches submissions, sends dynamic SendGrid templates, syncs CRM/webhook integrations, requests scheduling links, and persists records
- add scheduling metadata to the JSON response so the UI can surface meeting links or alternate CTAs
- update the frontend handler to render returned scheduling links/CTAs and add the node-fetch dependency for external API calls

## Testing
- npm run build --silent

------
https://chatgpt.com/codex/tasks/task_e_68dda8165c0c8327960c6371fe3bdc97