### PR TITLE
Add shortlist sharing API and UI

### DIFF
--- a/api/shortlist.js
+++ b/api/shortlist.js
@@ -1,0 +1,269 @@
+const fetch = require('node-fetch');
+const crypto = require('crypto');
+
+const listings = require('../data/listings.json');
+
+const {
+  NETLIFY_KV_REST_API_URL,
+  NETLIFY_KV_REST_TOKEN,
+  NETLIFY_KV_NAMESPACE,
+  SHORTLIST_TTL_SECONDS
+} = process.env;
+
+const TTL_SECONDS = Number.parseInt(SHORTLIST_TTL_SECONDS, 10) > 0
+  ? Number.parseInt(SHORTLIST_TTL_SECONDS, 10)
+  : 60 * 60 * 24 * 7; // default 7 days
+
+const baseHeaders = {
+  'Content-Type': 'application/json',
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+  'Access-Control-Allow-Headers': 'Content-Type',
+  'Cache-Control': 'no-store'
+};
+
+const canonicalMap = new Map();
+listings.forEach((entry) => {
+  if (entry && entry.id != null) {
+    canonicalMap.set(String(entry.id), entry);
+  }
+});
+
+const memoryStore = new Map();
+
+function jsonResponse(statusCode, body) {
+  return {
+    statusCode,
+    headers: baseHeaders,
+    body: JSON.stringify(body)
+  };
+}
+
+function dedupeIds(ids) {
+  const seen = new Set();
+  const ordered = [];
+  ids.forEach((id) => {
+    const key = String(id || '').trim();
+    if (!key || seen.has(key)) return;
+    if (!canonicalMap.has(key)) {
+      throw new Error(`Invalid listing id: ${key}`);
+    }
+    seen.add(key);
+    ordered.push(key);
+  });
+  return ordered;
+}
+
+function sanitizeListings(ids) {
+  return ids.map((id) => {
+    const canonical = canonicalMap.get(id);
+    return {
+      id: String(canonical.id),
+      title: canonical.title,
+      type: canonical.type,
+      city: canonical.city,
+      price: canonical.price,
+      priceDisplay: canonical.priceDisplay || null,
+      address: canonical.address || '',
+      details: canonical.details || '',
+      cover: canonical.cover || '',
+      webp: canonical.webp || '',
+      gallery: Array.isArray(canonical.gallery) ? canonical.gallery : [],
+      url: `/listings/${encodeURIComponent(canonical.id)}/`
+    };
+  });
+}
+
+function createSlug() {
+  if (typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID().replace(/-/g, '').slice(0, 12);
+  }
+  return `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function computeExpiry(ttlSeconds) {
+  const expires = new Date(Date.now() + ttlSeconds * 1000);
+  return expires.toISOString();
+}
+
+async function persistRecord(key, value, ttlSeconds) {
+  if (NETLIFY_KV_REST_API_URL && NETLIFY_KV_REST_TOKEN && NETLIFY_KV_NAMESPACE) {
+    const baseUrl = NETLIFY_KV_REST_API_URL.replace(/\/$/, '');
+    const encodedKey = encodeURIComponent(key);
+    const namespace = encodeURIComponent(NETLIFY_KV_NAMESPACE);
+    const url = `${baseUrl}/${namespace}/${encodedKey}?ttl=${ttlSeconds}`;
+    const res = await fetch(url, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${NETLIFY_KV_REST_TOKEN}`
+      },
+      body: JSON.stringify(value)
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`KV store responded with ${res.status}: ${text}`);
+    }
+    return;
+  }
+
+  const expiresAt = Date.now() + ttlSeconds * 1000;
+  memoryStore.set(key, { value, expiresAt });
+}
+
+async function readRecord(key) {
+  if (NETLIFY_KV_REST_API_URL && NETLIFY_KV_REST_TOKEN && NETLIFY_KV_NAMESPACE) {
+    const baseUrl = NETLIFY_KV_REST_API_URL.replace(/\/$/, '');
+    const encodedKey = encodeURIComponent(key);
+    const namespace = encodeURIComponent(NETLIFY_KV_NAMESPACE);
+    const url = `${baseUrl}/${namespace}/${encodedKey}`;
+    const res = await fetch(url, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${NETLIFY_KV_REST_TOKEN}`
+      }
+    });
+    if (res.status === 404) return null;
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`KV store responded with ${res.status}: ${text}`);
+    }
+    try {
+      return await res.json();
+    } catch (error) {
+      throw new Error(`Failed to parse stored shortlist: ${error.message}`);
+    }
+  }
+
+  const record = memoryStore.get(key);
+  if (!record) return null;
+  if (record.expiresAt && record.expiresAt < Date.now()) {
+    memoryStore.delete(key);
+    return null;
+  }
+  return record.value;
+}
+
+function extractRequestedIds(data) {
+  if (!data) return [];
+  if (Array.isArray(data.ids)) {
+    return data.ids.map((id) => String(id || '').trim()).filter(Boolean);
+  }
+  if (Array.isArray(data.listings)) {
+    return data.listings
+      .map((entry) => (entry && entry.id != null ? String(entry.id).trim() : ''))
+      .filter(Boolean);
+  }
+  return [];
+}
+
+async function handlePost(event) {
+  let payload;
+  try {
+    payload = event.body ? JSON.parse(event.body) : {};
+  } catch (error) {
+    return jsonResponse(400, { success: false, error: 'Invalid JSON payload.' });
+  }
+
+  const requested = extractRequestedIds(payload);
+  if (!requested.length) {
+    return jsonResponse(400, { success: false, error: 'Provide at least one listing id.' });
+  }
+
+  if (requested.length > 20) {
+    return jsonResponse(400, { success: false, error: 'You can only share up to 20 listings at a time.' });
+  }
+
+  let orderedIds;
+  try {
+    orderedIds = dedupeIds(requested);
+  } catch (error) {
+    return jsonResponse(400, { success: false, error: error.message });
+  }
+
+  if (!orderedIds.length) {
+    return jsonResponse(400, { success: false, error: 'No valid listings found to share.' });
+  }
+
+  const sanitizedListings = sanitizeListings(orderedIds);
+  const slug = createSlug();
+  const createdAt = new Date().toISOString();
+  const expiresAt = computeExpiry(TTL_SECONDS);
+
+  const record = {
+    slug,
+    createdAt,
+    expiresAt,
+    ttlSeconds: TTL_SECONDS,
+    listings: sanitizedListings,
+    meta: {
+      count: sanitizedListings.length,
+      ids: orderedIds
+    }
+  };
+
+  try {
+    await persistRecord(`shortlist:${slug}`, record, TTL_SECONDS);
+  } catch (error) {
+    console.error('Failed to persist shortlist', error);
+    return jsonResponse(503, { success: false, error: 'Shortlist sharing is temporarily unavailable.' });
+  }
+
+  return jsonResponse(201, {
+    success: true,
+    slug,
+    expiresAt,
+    createdAt,
+    ttlSeconds: TTL_SECONDS
+  });
+}
+
+async function handleGet(event) {
+  const params = event.queryStringParameters || {};
+  const slug = String(params.id || params.slug || '').trim();
+  if (!slug) {
+    return jsonResponse(400, { success: false, error: 'Missing shortlist id.' });
+  }
+
+  let record;
+  try {
+    record = await readRecord(`shortlist:${slug}`);
+  } catch (error) {
+    console.error('Failed to read shortlist', error);
+    return jsonResponse(503, { success: false, error: 'Unable to retrieve shortlist.' });
+  }
+
+  if (!record) {
+    return jsonResponse(404, { success: false, error: 'Shortlist not found or has expired.' });
+  }
+
+  const { expiresAt, listings: savedListings } = record;
+  if (expiresAt && Date.parse(expiresAt) && Date.parse(expiresAt) < Date.now()) {
+    return jsonResponse(404, { success: false, error: 'Shortlist not found or has expired.' });
+  }
+
+  return jsonResponse(200, {
+    slug: record.slug || slug,
+    createdAt: record.createdAt,
+    expiresAt: record.expiresAt,
+    ttlSeconds: record.ttlSeconds || TTL_SECONDS,
+    count: Array.isArray(savedListings) ? savedListings.length : 0,
+    listings: Array.isArray(savedListings) ? savedListings : []
+  });
+}
+
+exports.handler = async (event) => {
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 200, headers: baseHeaders };
+  }
+
+  if (event.httpMethod === 'POST') {
+    return handlePost(event);
+  }
+
+  if (event.httpMethod === 'GET') {
+    return handleGet(event);
+  }
+
+  return jsonResponse(405, { success: false, error: 'Method Not Allowed' });
+};

--- a/index.html
+++ b/index.html
@@ -233,6 +233,10 @@
         <div id="shortlist-cards" class="grid" aria-live="polite">
           <p class="small">Tap the ⭐ on any listing to save it here.</p>
         </div>
+        <div id="shortlist-share-tools" class="py-3 flex flex-wrap gap-2">
+          <button id="shortlist-share" class="btn" type="button" disabled aria-disabled="true">Share shortlist</button>
+        </div>
+        <div id="shortlist-share-output" class="small" aria-live="polite"></div>
       </div>
     </section>
 

--- a/js/shortlist-share.js
+++ b/js/shortlist-share.js
@@ -1,0 +1,144 @@
+/*! shortlist-share.js — hydrates shared shortlist pages */
+(function(){
+  const params = new URLSearchParams(window.location.search);
+  const slug = params.get('id') || params.get('share');
+  const mount = document.getElementById('shared-shortlist');
+  const statusEl = document.getElementById('shared-shortlist-status');
+  const metaEl = document.getElementById('shared-shortlist-meta');
+
+  if(!mount){ return; }
+
+  function escapeHtml(value){
+    return String(value ?? '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function escapeAttr(value){
+    return escapeHtml(value).replace(/`/g, '&#96;');
+  }
+
+  function setStatus(message){
+    if(statusEl){ statusEl.textContent = message; }
+  }
+
+  function renderListings(listings){
+    if(!Array.isArray(listings) || !listings.length){
+      mount.innerHTML = '<p class="small">This shortlist is empty.</p>';
+      return;
+    }
+    mount.innerHTML = listings.map(cardTpl).join('');
+    window.initShortlist?.();
+  }
+
+  function cardTpl(item){
+    const itemId = item && item.id != null ? String(item.id) : '';
+    const title = escapeHtml(item.title || 'Listing');
+    const detailUrl = escapeAttr(item.url || `/listings/${encodeURIComponent(itemId)}/`);
+    const price = item.priceDisplay || (typeof item.price === 'number' ? `$${item.price.toLocaleString()}` : '');
+    const typeCity = [item.type, item.city].filter(Boolean).join(' • ');
+    const details = item.details ? `<p class="m-0 small">${escapeHtml(item.details)}</p>` : '';
+    const address = item.address ? `<p class="m-0 small">${escapeHtml(item.address)}</p>` : '';
+    const webp = item.webp && item.webp.endsWith('.webp')
+      ? `<source type="image/webp" srcset="${escapeAttr(item.webp)}">`
+      : '';
+    const cover = escapeAttr(item.cover || item.img || '');
+    const aria = escapeAttr(`View ${item.title || 'listing'} details`);
+    return `
+    <article class="card col-12" data-id="${escapeHtml(itemId)}">
+      <a href="${detailUrl}" class="block" aria-label="${aria}">
+        <picture>
+          ${webp}
+          <img class="listing-photo" src="${cover}" alt="${title}">
+        </picture>
+      </a>
+      <div class="card-body">
+        <h3 class="m-0">${title}</h3>
+        ${typeCity ? `<div class="meta">${escapeHtml(typeCity)}</div>` : ''}
+        ${price ? `<div class="price">${escapeHtml(price)}</div>` : ''}
+        ${details}
+        ${address}
+        <div class="py-3 flex flex-wrap gap-2">
+          <a class="btn" href="${detailUrl}">View details</a>
+          <button class="btn js-save-listing" aria-pressed="false" type="button">
+            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M12 17.27l6.18 3.73-1.64-7.03L21.5 9.24l-7.19-.61L12 2 9.69 8.63 2.5 9.24l4.96 4.73L5.82 21z"/></svg>
+            Save
+          </button>
+        </div>
+      </div>
+    </article>
+    `;
+  }
+
+  function formatRelative(diffMs){
+    if(diffMs <= 0) return 'now';
+    const minutes = Math.round(diffMs / 60000);
+    if(minutes < 60) return `in ${minutes} minute${minutes === 1 ? '' : 's'}`;
+    const hours = Math.round(diffMs / 3600000);
+    if(hours < 48) return `in ${hours} hour${hours === 1 ? '' : 's'}`;
+    const days = Math.round(diffMs / 86400000);
+    return `in ${days} day${days === 1 ? '' : 's'}`;
+  }
+
+  function hydrateMeta(data){
+    if(!metaEl) return;
+    const count = Number(data?.count ?? (data?.listings?.length || 0));
+    const parts = [];
+    if(count){ parts.push(`${count} saved listing${count === 1 ? '' : 's'}.`); }
+    if(data?.createdAt){
+      const created = new Date(data.createdAt);
+      if(!Number.isNaN(created.getTime())){
+        parts.push(`Shared ${created.toLocaleString()}.`);
+      }
+    }
+    if(data?.expiresAt){
+      const expiry = new Date(data.expiresAt);
+      if(!Number.isNaN(expiry.getTime())){
+        const diff = expiry.getTime() - Date.now();
+        const rel = formatRelative(diff);
+        parts.push(diff <= 0
+          ? 'Link has expired.'
+          : `Link expires ${rel} (${expiry.toLocaleString()}).`);
+      }
+    }
+    metaEl.textContent = parts.join(' ') || '';
+  }
+
+  async function hydrate(){
+    if(!slug){
+      setStatus('Shortlist link is missing.');
+      mount.innerHTML = '';
+      return;
+    }
+    setStatus('Loading shortlist…');
+    try{
+      const res = await fetch(`/.netlify/functions/shortlist?id=${encodeURIComponent(slug)}`);
+      if(res.status === 404){
+        setStatus('This shortlist is unavailable. It may have expired or the link is incorrect.');
+        mount.innerHTML = '';
+        return;
+      }
+      if(!res.ok){
+        throw new Error(`Request failed with status ${res.status}`);
+      }
+      const data = await res.json();
+      if(!Array.isArray(data?.listings) || !data.listings.length){
+        setStatus('This shortlist is empty.');
+        renderListings([]);
+        hydrateMeta(data);
+        return;
+      }
+      setStatus('');
+      renderListings(data.listings);
+      hydrateMeta(data);
+    }catch(error){
+      console.error('Failed to load shared shortlist', error);
+      setStatus('We couldn’t load this shortlist right now. Please try again later or request a new link.');
+    }
+  }
+
+  hydrate();
+})();

--- a/js/shortlist.js
+++ b/js/shortlist.js
@@ -4,24 +4,49 @@
   const KEY = 'shortlistV1';
   let bound = false;
 
+  const toastManager = (()=>{
+    let storageToast = null;
+    let shareToast = null;
+    let shareTimer = null;
+
+    function ensureStorageToast(){
+      if(storageToast) return storageToast;
+      storageToast = document.createElement('div');
+      storageToast.className = 'storage-toast';
+      storageToast.setAttribute('role', 'status');
+      storageToast.textContent = 'Saved listings are unavailable in this browser.';
+      document.body.appendChild(storageToast);
+      requestAnimationFrame(()=>storageToast.classList.add('is-visible'));
+      return storageToast;
+    }
+
+    function showShareError(message){
+      if(!shareToast){
+        shareToast = document.createElement('div');
+        shareToast.className = 'storage-toast shortlist-toast-error';
+        shareToast.setAttribute('role', 'status');
+        document.body.appendChild(shareToast);
+      }
+      shareToast.textContent = message;
+      requestAnimationFrame(()=>shareToast.classList.add('is-visible'));
+      if(shareTimer) clearTimeout(shareTimer);
+      shareTimer = setTimeout(()=>{
+        shareToast.classList.remove('is-visible');
+      }, 4000);
+    }
+
+    return {
+      warnStorage(){ ensureStorageToast(); },
+      shareError(message){ showShareError(message); }
+    };
+  })();
+
   const safeStorage = (()=>{
     let warned = false;
-    let toast = null;
-
-    function showToast(){
-      if(toast) return toast;
-      toast = document.createElement('div');
-      toast.className = 'storage-toast';
-      toast.setAttribute('role', 'status');
-      toast.textContent = 'Saved listings are unavailable in this browser.';
-      document.body.appendChild(toast);
-      requestAnimationFrame(()=>toast.classList.add('is-visible'));
-      return toast;
-    }
 
     function warn(e){
       console.warn('Storage access failed', e);
-      if(!warned){ warned = true; showToast(); }
+      if(!warned){ warned = true; toastManager.warnStorage(); }
     }
 
     return {
@@ -47,6 +72,152 @@
     catch{ return {}; }
   }
   function save(data){ return safeStorage.set(KEY, JSON.stringify(data)); }
+
+  const shareState = { loading:false, url:'', expiresAt:null };
+  const shareUI = { button:null, output:null, bound:false };
+
+  function getShareElements(){
+    if(!shareUI.button){ shareUI.button = document.getElementById('shortlist-share'); }
+    if(!shareUI.output){ shareUI.output = document.getElementById('shortlist-share-output'); }
+    if(shareUI.button && !shareUI.bound){
+      shareUI.button.addEventListener('click', onShareClick);
+      shareUI.bound = true;
+    }
+    if(shareUI.output && !shareUI.output.dataset.bound){
+      shareUI.output.addEventListener('click', onShareOutputClick);
+      shareUI.output.dataset.bound = 'true';
+    }
+    return shareUI;
+  }
+
+  function updateShareAvailability(items){
+    const { button, output } = getShareElements();
+    if(!button) return;
+    const hasItems = items.length > 0;
+    const isDisabled = !hasItems || shareState.loading;
+    button.disabled = isDisabled;
+    button.setAttribute('aria-disabled', isDisabled ? 'true' : 'false');
+    button.setAttribute('aria-busy', shareState.loading ? 'true' : 'false');
+    button.textContent = shareState.loading ? 'Generating…' : 'Share shortlist';
+    if(!hasItems){
+      shareState.url = '';
+      shareState.expiresAt = null;
+      if(output){ output.innerHTML = ''; }
+    }
+  }
+
+  function showShareMessage(message){
+    const { output } = getShareElements();
+    if(!output) return;
+    if(!message){ output.innerHTML = ''; return; }
+    output.innerHTML = `<p class="small">${escapeHtml(message)}</p>`;
+  }
+
+  function formatExpiry(expiresAt){
+    if(!expiresAt) return '';
+    const expiry = new Date(expiresAt);
+    if(Number.isNaN(expiry.getTime())) return '';
+    const diff = expiry.getTime() - Date.now();
+    if(diff <= 0) return 'now';
+    const minutes = Math.round(diff / 60000);
+    if(minutes < 60) return `in ${minutes} minute${minutes===1?'':'s'} (${expiry.toLocaleString()})`;
+    const hours = Math.round(diff / 3600000);
+    if(hours < 48) return `in ${hours} hour${hours===1?'':'s'} (${expiry.toLocaleString()})`;
+    const days = Math.round(diff / 86400000);
+    return `in ${days} day${days===1?'':'s'} (${expiry.toLocaleString()})`;
+  }
+
+  function displayShareResult(url, expiresAt, count){
+    const { output } = getShareElements();
+    if(!output) return;
+    const expiryText = formatExpiry(expiresAt);
+    shareState.url = url;
+    shareState.expiresAt = expiresAt;
+    const emailSubject = encodeURIComponent('Shared shortlist');
+    const emailBody = encodeURIComponent(`Here’s a shortlist of ${count} listing${count===1?'':'s'}: ${url}`);
+    const whatsappHref = `https://wa.me/?text=${encodeURIComponent(`Check out these listings: ${url}`)}`;
+    const safeUrl = escapeHtml(url);
+    const attrUrl = escapeAttr(url);
+    const emailHref = escapeAttr(`mailto:?subject=${emailSubject}&body=${emailBody}`);
+    const whatsappAttr = escapeAttr(whatsappHref);
+    output.innerHTML = `
+      <div class="card" style="padding: 1rem;">
+        <p class="m-0"><strong>Share link</strong></p>
+        <p class="m-0" style="word-break: break-word;"><a href="${attrUrl}" target="_blank" rel="noopener">${safeUrl}</a></p>
+        ${expiryText ? `<p class="m-0 small">Link expires ${escapeHtml(expiryText)}.</p>` : ''}
+        <div class="py-3 flex flex-wrap gap-2">
+          <button class="btn ghost" type="button" data-share-copy>Copy link</button>
+          <a class="btn ghost" data-share-email href="${emailHref}">Email</a>
+          <a class="btn ghost" data-share-whatsapp href="${whatsappAttr}" target="_blank" rel="noopener">WhatsApp</a>
+        </div>
+      </div>
+    `;
+  }
+
+  async function onShareClick(e){
+    e.preventDefault();
+    const data = load();
+    const items = Object.values(data);
+    if(!items.length){
+      showShareMessage('Save at least one listing to share.');
+      return;
+    }
+    shareState.loading = true;
+    updateShareAvailability(items);
+    showShareMessage('Generating share link…');
+    try{
+      const payload = {
+        ids: items.map(item=>item.id),
+        listings: items
+      };
+      const res = await fetch('/.netlify/functions/shortlist', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+      const json = await res.json().catch(()=>({ success:false }));
+      if(!res.ok || !json?.success){
+        const msg = json?.error || `Request failed with status ${res.status}`;
+        throw new Error(msg);
+      }
+      const slug = json.slug;
+      const expiresAt = json.expiresAt;
+      const shareUrl = `${window.location.origin}/shortlist.html?id=${encodeURIComponent(slug)}`;
+      displayShareResult(shareUrl, expiresAt, items.length);
+    }catch(error){
+      console.error('Shortlist share failed', error);
+      toastManager.shareError('Unable to share shortlist. Please try again.');
+      showShareMessage('Unable to generate a share link. Please try again.');
+    }finally{
+      shareState.loading = false;
+      updateShareAvailability(Object.values(load()));
+    }
+  }
+
+  function onShareOutputClick(e){
+    const copyBtn = e.target.closest('[data-share-copy]');
+    if(copyBtn){
+      e.preventDefault();
+      if(!shareState.url){
+        toastManager.shareError('Share link unavailable. Try generating a new link.');
+        return;
+      }
+      if(navigator.clipboard?.writeText){
+        navigator.clipboard.writeText(shareState.url)
+          .then(()=>{
+            const original = copyBtn.textContent;
+            copyBtn.textContent = 'Copied!';
+            setTimeout(()=>{ copyBtn.textContent = original; }, 2000);
+          })
+          .catch(()=>{
+            toastManager.shareError('Copy failed. Use your browser menu to copy the link.');
+          });
+      }else{
+        toastManager.shareError('Copy is not supported in this browser.');
+      }
+      return;
+    }
+  }
 
   function toggle(card){
     const id = card.dataset.id;
@@ -89,6 +260,7 @@
     document.querySelectorAll('[data-id]').forEach(card=>{
       updateUI(card, !!data[card.dataset.id]);
     });
+    updateShareAvailability(Object.values(data));
   }
 
   function renderShortlist(){
@@ -98,6 +270,20 @@
     const items = Object.values(data);
     mount.innerHTML = items.length ? items.map(tpl).join('') :
       `<p class="small">No saved listings yet. Tap the ⭐ on any card to add it here.</p>`;
+    updateShareAvailability(items);
+  }
+
+  function escapeHtml(value){
+    return String(value ?? '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function escapeAttr(value){
+    return escapeHtml(value).replace(/`/g, '&#96;');
   }
 
   function tpl(it){
@@ -139,6 +325,7 @@
       document.addEventListener('click', onClick);
       bound = true;
     }
+    getShareElements();
     hydrate(); renderShortlist();
   }
 
@@ -149,6 +336,7 @@
   .js-save-listing.is-saved svg{fill-opacity:1}
   .storage-toast{position:fixed;bottom:1.25rem;right:1.25rem;padding:.75rem 1rem;border-radius:.75rem;background:color-mix(in oklab, var(--ink) 85%, transparent);color:var(--paper, #fff);font-size:.875rem;box-shadow:0 0.75rem 1.5rem rgba(0,0,0,.2);opacity:0;transform:translateY(12px);transition:opacity .3s ease, transform .3s ease;pointer-events:none;z-index:999}
   .storage-toast.is-visible{opacity:1;transform:translateY(0)}
+  .shortlist-toast-error{bottom:calc(1.25rem + 3.5rem)}
   `;
   const style = document.createElement('style'); style.textContent = css; document.head.appendChild(style);
 

--- a/shortlist.html
+++ b/shortlist.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Shared Shortlist — Ishwinder Ghag Realty</title>
+  <link rel="stylesheet" href="/styles/main.css">
+</head>
+<body>
+  <header class="container" style="padding:2rem 1rem 1rem;">
+    <a href="/" class="small">← Back to home</a>
+    <h1 class="m-0">Shared Shortlist</h1>
+    <p id="shared-shortlist-meta" class="small"></p>
+  </header>
+  <main class="container" style="padding:0 1rem 3rem;">
+    <p id="shared-shortlist-status" class="small" role="status" aria-live="polite"></p>
+    <div id="shared-shortlist" class="grid" aria-live="polite"></div>
+  </main>
+  <script defer src="/js/shortlist.js"></script>
+  <script defer src="/js/shortlist-share.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a Netlify Function that validates shortlist submissions against the listings dataset, persists them with TTL metadata, and serves stored payloads
- expand the saved listings UI with a share workflow that generates copy/email/WhatsApp links and error toasts, plus a dedicated shared shortlist page

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ddafa047b083279f9c555077b8bab2