### PR TITLE
Add backend anti-spam handling to contact API

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node test/contact.test.js",
     "start": "node api/contact.js",
     "build:listings": "node scripts/build-listings.js",
     "build": "npm run build:listings"

--- a/test/contact.test.js
+++ b/test/contact.test.js
@@ -1,0 +1,54 @@
+const assert = require('assert');
+const { buildPayload, validatePayload, stripAntiSpamFields } = require('../api/contact');
+
+function runTest(name, fn) {
+  try {
+    fn();
+    console.log(`✓ ${name}`);
+  } catch (error) {
+    console.error(`✗ ${name}`);
+    console.error(error);
+    process.exitCode = 1;
+  }
+}
+
+const baseData = {
+  name: 'Test User',
+  email: 'USER@example.com',
+  message: 'Hello there!'
+};
+
+runTest('buildPayload captures anti-spam fields', () => {
+  const payload = buildPayload({ ...baseData, website: '  https://spam.example  ', ttv: ' 2500ms ' });
+  assert.strictEqual(payload.honeypot, 'https://spam.example');
+  assert.strictEqual(payload.timeToSubmitMs, 2500);
+});
+
+runTest('validatePayload rejects submissions with honeypot content', () => {
+  const payload = buildPayload({ ...baseData, website: 'bot' });
+  const result = validatePayload(payload);
+  assert.strictEqual(result, 'Message is required');
+});
+
+runTest('validatePayload rejects submissions under minimum time threshold', () => {
+  const payload = buildPayload({ ...baseData, ttv: '2999' });
+  const result = validatePayload(payload);
+  assert.strictEqual(result, 'Message is required');
+});
+
+runTest('validatePayload accepts legitimate submissions', () => {
+  const payload = buildPayload({ ...baseData, ttv: '3500' });
+  const result = validatePayload(payload);
+  assert.strictEqual(result, null);
+});
+
+runTest('stripAntiSpamFields omits honeypot and time fields', () => {
+  const payload = buildPayload({ ...baseData, website: '', ttv: '5000' });
+  const safe = stripAntiSpamFields(payload);
+  assert.ok(!Object.prototype.hasOwnProperty.call(safe, 'honeypot'));
+  assert.ok(!Object.prototype.hasOwnProperty.call(safe, 'timeToSubmitMs'));
+});
+
+if (process.exitCode) {
+  process.exit(process.exitCode);
+}


### PR DESCRIPTION
## Summary
- sanitize honeypot and time-to-submit fields from contact form payloads and enforce a three-second minimum
- strip anti-spam data before invoking email delivery, CRM sync, and persistence helpers
- add lightweight unit tests for contact validation and wire them into the npm test script

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ddb3acfab4832789c1dc592c042d1b